### PR TITLE
Update build_frontend.sh

### DIFF
--- a/build_frontend.sh
+++ b/build_frontend.sh
@@ -1,4 +1,5 @@
 cd frontend/
 npm run build
-cp -r dist/ ../resources/frontend/static/
+rm -rf ../resources/frontend/static/*
+cp -r dist/* ../resources/frontend/static/
 cd ..


### PR DESCRIPTION
Fixed error that copied the directory `dist` instead of the contents. Addresses #36. 
Also added line to delete `static`'s content to prevent swelling from old files.